### PR TITLE
fix: text color issue on splash screen #272

### DIFF
--- a/src/components/SplashScreen.jsx
+++ b/src/components/SplashScreen.jsx
@@ -9,7 +9,7 @@ const SplashScreen = () => {
         <div className="w-8 h-8 from-indigo-500 via-purple-500 to-pink-500 bg-gradient-to-r rounded-full"></div>
       </div>
 
-      <div className="mt-4 text-xl font-bold text-white flex items-center justify-center">Loading...</div>
+      <div className="mt-4 text-xl font-bold flex items-center justify-center">Loading...</div>
     </div>
   )
 }


### PR DESCRIPTION
## Description

This PR fixes the text color issue on SplashScreen reported in [#272](https://github.com/priyankarpal/ProjectsHut/issues/272)

## Screenshots
<img width="1678" alt="Screenshot 2023-04-25 at 1 25 17 PM" src="https://user-images.githubusercontent.com/88369802/234219195-929d8120-2437-4ca5-a3f4-b3d9a7377011.png">

## Checklist

Please review and check off the following items before submitting your PR:

 <!-- If yes then add 'x' into '[ ]'  -->

- [x] I have tested my changes to ensure they work as expected
- [ ] I have included documentation for any new features or changes
- [x] I have formatted my code according to the project's style guidelines
- [ ] I have written tests for any new features or changes
- [x] I have run the project's test suite and verified that all tests pass
- [ ] I have updated the README and any other relevant documentation
- [x] I have checked for any spelling or grammatical errors
