### PR TITLE
Update contributing.md

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -69,6 +69,15 @@ git add .
 ```diff
 git commit -m "Your Changes"
 ```
+> If you encounter this error while commits
+>
+>```diff
+>husky - pre-commit hook exited with code 1(error)
+>```
+> use this command
+> ```diff
+> pnpm format
+> ```
 
 11. Set upstream command
 


### PR DESCRIPTION
## Description

**husky - pre-commit hook exited** is the most common error encountered while committing the files which stops the work flow. So I wanted to add these lines and make easier for contributors not to search for the error.

<!--
Is there anything else you would like to include about your PR? This could include information about how to test your changes or any potential issues that may arise.

Thank you for contributing to the Projectshut Open Source website!
 -->
