### PR TITLE
made the navbar sticky with a blur/translucent and improved UI of navbar

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -14,11 +14,22 @@ const Navbar = () => {
   const { navbar } = theme
 
   const handleDrawerToggle = () => {
-    setMobileOpen(!mobileOpen)
+    setMobileOpen(!mobileOpen) 
   }
 
   return (
-    <nav aria-label="Site Nav" className=" mx-auto p-5 lg:w-1/2">
+    <nav
+      aria-label="Site Nav"
+      className="mx-auto p-5 lg:w-1/2"
+      style={{
+        boxShadow: "0 0 10px 0 rgba(0, 0, 0, 0.2)",
+        background: "rgba(255, 255, 255, 0.05)",
+        position: "relative",
+        zIndex: 1,
+        position:"sticky",
+        top:0
+      }}
+    >
       <div className="flex flex-row justify-between">
         {/* Logo for project Hut */}
         <div className="item-navbar block md:hidden" id="dropdown-menu">
@@ -38,11 +49,11 @@ const Navbar = () => {
 
         {/* Main element of navbar */}
         <div className="item-navbar hidden md:block" id="elements-of-navbar">
-          <ul className="flex items-center gap-5  text-[1rem]">
+        <ul className="flex items-center gap-5 text-[1rem]">
             <li>
               <NavLink
                 to="/"
-                className="inline-block py-2 px-3 text-center font-bold  rounded-md focus:outline-none focus:ring focus:ring-gray-800"
+                className="inline-block py-2 px-3 text-center font-bold rounded-md focus:outline-none focus:ring focus:ring-gray-800 hover:text-gray-800 hover:bg-white"
               >
                 Home
               </NavLink>
@@ -50,7 +61,7 @@ const Navbar = () => {
             <li>
               <NavLink
                 to="/projectspage"
-                className="inline-block py-2 px-3 text-center font-bold rounded-md  focus:outline-none focus:ring focus:ring-gray-800 "
+                className="inline-block py-2 px-3 text-center font-bold rounded-md focus:outline-none focus:ring focus:ring-gray-800 hover:text-gray-800 hover:bg-white"
               >
                 Projects
               </NavLink>
@@ -58,7 +69,7 @@ const Navbar = () => {
             <li>
               <NavLink
                 to="/docs"
-                className="inline-block py-2 px-3 text-center font-bold  rounded-md   focus:outline-none focus:ring focus:ring-gray-800"
+                className="inline-block py-2 px-3 text-center font-bold rounded-md focus:outline-none focus:ring focus:ring-gray-800 hover:text-gray-800 hover:bg-white"
               >
                 Docs
               </NavLink>
@@ -66,7 +77,7 @@ const Navbar = () => {
             <li>
               <NavLink
                 to="/contributorspage"
-                className="inline-block py-2 px-3 text-center font-bold  rounded-md   focus:outline-none focus:ring focus:ring-gray-800"
+                className="inline-block py-2 px-3 text-center font-bold rounded-md focus:outline-none focus:ring focus:ring-gray-800 hover:text-gray-800 hover:bg-white"
               >
                 Contributors
               </NavLink>


### PR DESCRIPTION
made the navbar sticky with a blur/translucent and improved UI of navbar by adding hover effects to the navbar links

## Related Issue
#482 

<!-- If there is no issue number, the PR will not be merged. Therefore, please ensure that the issue number is added -->

## Description
made the navbar background translucent with some blur and added box shadow and to comply with the navbar design, added some hover effects to the navbar links as well with additional prominency in dark mode.
<!-- Please provide more context or information for us to properly rewrite your statement  -->
<img width="1792" alt="Screenshot 2023-05-22 at 2 44 15 PM" src="https://github.com/priyankarpal/ProjectsHut/assets/95973644/2f0886a6-a83c-43ab-a45d-003a8b9e549e">

## Screenshots
<img width="1776" alt="Screenshot 2023-05-22 at 2 34 28 PM" src="https://github.com/priyankarpal/ProjectsHut/assets/95973644/c2d4432e-3666-422d-a8c6-d1d2a4c0c8a2">

<img width="1761" alt="Screenshot 2023-05-22 at 2 45 57 PM" src="https://github.com/priyankarpal/ProjectsHut/assets/95973644/d501c079-4a9c-4b82-a9a6-8331dbe0eec1">

<!-- Add screenshots to preview the changes  -->
