### PR TITLE
#901-fixed projects link in mobile

### DIFF
--- a/src/components/SideMenu.jsx
+++ b/src/components/SideMenu.jsx
@@ -58,7 +58,7 @@ export default function SideMenu(props) {
         </li>
         <li>
           <NavLink
-            to="/projectspage"
+            to="/projects"
             className={`block py-2 px-3 text-left font-bold rounded-md ${
               theme.mode === 'light'
                 ? 'hover:text-white hover:bg-black focus:text-white focus:bg-black'


### PR DESCRIPTION
## Related Issue
#901 
Projects page link fixed in navbar

## Description
#901 
The link in sidemenu was referring to path /projectsPage but it does not exist .So changed it to projects

## Screenshots
[scrnli_27_05_2023_20-11-34.webm](https://github.com/priyankarpal/ProjectsHut/assets/92094765/d65ac32e-967a-475e-83aa-734cc99b4f94)

