### PR TITLE
Added Github Action for Labelling PR

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -1,0 +1,9 @@
+---
+level1:
+  - "src/DB/*"
+level2:
+  - "src/components/*"
+  - "src/pages/*"
+  - "src/utils/*"
+level3:
+  - "**/*"

--- a/.github/workflows/ph-labeler.yaml
+++ b/.github/workflows/ph-labeler.yaml
@@ -1,0 +1,23 @@
+---
+name: "ProjectsHut Labeler"
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: ["main", "dev"]
+
+permissions:
+  checks: write
+  contents: read
+  pull-requests: write
+
+jobs:
+  labeler:
+    name: Labeler
+    runs-on: ubuntu-latest
+    steps:
+      - name: Labeler
+        uses: actions/labeler@0776a679364a9a16110aac8d0f40f5e11009e327 # v4.0.4
+        with:
+          configuration-path: .github/labeler.yaml
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Related Issue
- Fixes #931 

## Description
- Added Github Action for Labelling GSSoC PRs according to the level of contribution made
- Used the `labeler` GitHub Action for implementation
