### PR TITLE
Docs: add contributors graph with dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,19 @@ Contributions are welcome! If you have any ideas, suggestions, or bug fixes, ple
 
 🌟 We value the time and effort you put into contributing, and we look forward to reviewing and merging your contributions. Join us on this exciting journey of creativity and collaboration, and let your projects shine on Projectshut!
 
+⚡ Wanna see our the contributors ? (then click the below dropdown)
+<!-- a big thanks to all the contributors -->
+<details align=center>
+<summary>Contributors are here!!</summary>
+
+<center>
+<a href="https://github.com/priyankarpal/ProjectsHut/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=priyankarpal/ProjectsHut" />
+</a>
+</center>
+
+</details>
+
 ## ✨Authors
 
 [Priyankar Pal](https://github.com/priyankarpal) - Project Admin


### PR DESCRIPTION
## Related Issue
- Closes/Fixes: #1022 

## Description
- Added repository Contributors graph which shows an overall picture of all contributors who contributed to this project/repository
- Additionally we added a dropdown menu using `details` & `summary`, So that the Graph itself will not consume more space until we open it to see it

## Screenshots
![image](https://github.com/priyankarpal/ProjectsHut/assets/92252895/7779b09d-40aa-4c98-aea5-28465f06945b)
![image](https://github.com/priyankarpal/ProjectsHut/assets/92252895/dba78289-8a4e-45f9-9308-3e8ff5d47502)

