### PR TITLE
fix: Back to projects button resets the selected filters. 

### DIFF
--- a/src/components/ProjectList.jsx
+++ b/src/components/ProjectList.jsx
@@ -42,7 +42,7 @@ const ProjectList = () => {
           <div className="m-4 hover:text-purple-500 transition-all duration-300 ease-in-out flex gap-2 items-center">
             <ArrowLeftCircle size={20} />
 
-            <Link to={`/projectspage${filter ? `?filter=${filter}` : ''}`} className="ml-2">
+            <Link to={`/projectspage${filter ? `?filters=${filter}` : ''}`} className="ml-2">
               {`Back to ${filter ? filter.charAt(0).toUpperCase() + filter.slice(1) : 'All'} Projects`}
             </Link>
           </div>


### PR DESCRIPTION
## Related Issue
issue #1076 

## Description
The `Back to [selected filters] projects` button works as intended - persists the selected filters when navigated back to projects page

## Screenshots

<!-- Add screenshots to preview the changes  -->
