### PR TITLE
fix: project page path error for side-menu

### DIFF
--- a/src/components/SideMenu.jsx
+++ b/src/components/SideMenu.jsx
@@ -20,7 +20,7 @@ function SideMenu(props) {
     },
     {
       name: 'Projects',
-      path: '/projects',
+      path: '/projectspage',
     },
     {
       name: 'Documentation',


### PR DESCRIPTION
## Related Issue

Closes : #1074 

## Description

- #### Added Project page path for small screens when nav-bar turns into side-menu resulting user to open project page on mobile screen using side-menu as well.

## Screenshots

![image](https://github.com/priyankarpal/ProjectsHut/assets/115401171/099ce7b8-ab5f-4489-9d84-6b628fe1b5d4)
