### PR TITLE
fix: Replaced copy text with ClipBoard icon

### DIFF
--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { GitBranch, FileText, UploadCloud } from "react-feather";
+import { GitBranch, FileText, UploadCloud, Clipboard, CheckCircle } from "react-feather";
 import { useEffect, ReactNode, useState } from "react";
 import SyntaxHighlighter from "react-syntax-highlighter";
 import { anOldHope } from "react-syntax-highlighter/dist/esm/styles/hljs";
@@ -139,15 +139,12 @@ const option2Steps = [
 ];
 
 function Step({ icon, text, code, image }: StepProps): JSX.Element {
+  const [copyCodeButton, setcopyCodeButton] = useState(true)
   const copyCode = (e: React.MouseEvent<HTMLButtonElement, MouseEvent>): void => {
-    const button = e.currentTarget as HTMLButtonElement;
-    const initialText = button.innerText;
-
+    setcopyCodeButton(false)
     navigator.clipboard.writeText(code);
-    button.innerText = "Copied!";
-
     setTimeout(() => {
-      button.innerText = initialText;
+      setcopyCodeButton(true)
     }, 3000);
   };
 
@@ -167,7 +164,8 @@ function Step({ icon, text, code, image }: StepProps): JSX.Element {
                 onClick={copyCode}
                 className="cursor-pointer text-indigo-600"
               >
-                Copy
+                {copyCodeButton && <Clipboard size='18' color="white"/>}
+                {!copyCodeButton && <CheckCircle size='18' color="green"/>}
               </button>
             </div>
           )}


### PR DESCRIPTION
#1249 

## Description

Replaced the copy button text with a clipboard icon. On clicking the icon a green check will appear for 3 seconds indicating that the text has been copied

## Screenshots


<img width="1069" alt="Screenshot 2023-07-09 at 2 47 12 AM" src="https://github.com/priyankarpal/ProjectsHut/assets/77684943/2eec2b36-0f4a-4ccb-ab8e-d9ad3e1c2119">




On clicking:

<img width="1055" alt="Screenshot 2023-07-09 at 2 47 38 AM" src="https://github.com/priyankarpal/ProjectsHut/assets/77684943/302d1a17-f96b-41e6-96e5-aed98bde2755">
