### PR TITLE
docs: add dark/light theme adaptable gssoc banner 💡

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ We value the time and effort you put into contributing, and we look forward to r
 </table>
 <div align=center>
   <h2>This Project is part of</h2>
-  <img alt="GSSoC" src="https://github.com/priyankarpal/ProjectsHut/assets/88102392/0c5debf5-d414-4916-87d8-e1a710773ae3">
+  <img alt="GSSoC" src="https://raw.githubusercontent.com/GirlScriptSummerOfCode/MentorshipProgram/master/GSsoc%20Type%20Logo%20Black.png#gh-light-mode-only" width=87%>
+  <img alt="GSSoC" src="https://user-images.githubusercontent.com/63473496/213306279-338f7ce9-9a9f-4427-8c2a-3e344874498f.png#gh-dark-mode-only"/>
 </div>
 
 ## ©️ License


### PR DESCRIPTION
## Related Issue

Closes #1631 

## Description
- This PR is about making the GSSoC Banner adaptable for Dark/Light Mode of Github.
- The banner will be swapped according to the theme preference, it uses Github's inbuilt functionality.

## Screenshots
| WITHOUT USING GITHUB'S FEATURE |
| :--: |
| ![](https://github.com/priyankarpal/ProjectsHut/assets/92252895/2a358a0b-b1f7-454a-85eb-00c0ed7e7ce6) |

<br>

<div align=center>

**AFTER USING GITHUB'S FEATURE**

</div>

| DARK THEME | LIGHT THEME |
| :--: | :---: |
| ![](https://github.com/priyankarpal/ProjectsHut/assets/92252895/14255d1a-8b86-4115-9634-c6aeb352fb12) | ![](https://github.com/priyankarpal/ProjectsHut/assets/92252895/abee8768-ada5-4b54-a3aa-ec4831c79933) |

