### PR TITLE
fix: Opens Github link in new tab

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -4,9 +4,15 @@ import { NextPage } from "next";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
+interface NavLink {
+  name: string;
+  path: string;
+  external?: boolean;
+}
+
 const Navbar: NextPage = () => {
   const activePath = usePathname();
-  const navLinks = [
+  const navLinks: NavLink[] = [
     {
       name: "Home",
       path: "/",
@@ -22,6 +28,7 @@ const Navbar: NextPage = () => {
     {
       name: "GitHub",
       path: "https://github.com/priyankarpal/ProjectsHut",
+      external: true,
     },
   ];
 
@@ -40,20 +47,38 @@ const Navbar: NextPage = () => {
           </div>
 
           {/* Main element of navbar */}
-          <div className="item-navbar hidden md:block" id="elements-of-navbar">
+          <div
+            className="item-navbar hidden md:block"
+            id="elements-of-navbar"
+          >
             <ul className="flex items-center gap-5 text-[1rem]">
               {navLinks.map((navLink) => (
                 <li key={navLink.path}>
-                  <Link
-                    href={navLink.path}
-                    className={
-                      activePath === navLink.path
-                        ? "inline-block py-2 px-3 text-center text-primary  hover:text-primary rounded-lg"
-                        : "inline-block py-2 px-3 text-center text-white  hover:text-primary rounded-lg"
-                    }
-                  >
-                    {navLink.name}
-                  </Link>
+                  {navLink.external ? (
+                    <a
+                      href={navLink.path}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className={
+                        activePath === navLink.path
+                          ? "inline-block py-2 px-3 text-center text-primary hover:text-primary rounded-lg"
+                          : "inline-block py-2 px-3 text-center text-white hover:text-primary rounded-lg"
+                      }
+                    >
+                      {navLink.name}
+                    </a>
+                  ) : (
+                    <Link
+                      href={navLink.path}
+                      className={
+                        activePath === navLink.path
+                          ? "inline-block py-2 px-3 text-center text-primary hover:text-primary rounded-lg"
+                          : "inline-block py-2 px-3 text-center text-white hover:text-primary rounded-lg"
+                      }
+                    >
+                      {navLink.name}
+                    </Link>
+                  )}
                 </li>
               ))}
             </ul>


### PR DESCRIPTION
Related issue: 
Closes #1670 
  
Updated Navbar component to open the GitHub link in a new tab

This pull request modifies the Navbar component to enhance user experience by opening the GitHub link in a new tab when clicked. Previously, the link would navigate within the same tab, causing users to leave the current website.

To achieve this, the following changes were made:
- Added the 'target="_blank"' attribute to the <a> tag wrapping the GitHub link.
- Introduced the 'external' property in the navLinks array to indicate an external link.
- Updated the rendering logic to conditionally render an <a> tag for external links with the appropriate attributes.

Now, when users click on the GitHub link in the navbar, it will open in a new tab, allowing them to easily navigate to the GitHub repository without leaving the current website.

This improvement enhances usability and provides a seamless browsing experience for users. The code changes have been tested and verified to work as intended.

Please review and merge this pull request to incorporate the changes.


