### PR TITLE
fix: Makes the Browse Projects button visible in mobile mode

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,7 +20,7 @@ export default function HomePage() {
                 projects with the world.
               </p>
 
-              <div className="mt-14">
+              <div className="mt-14 my-1">
                 <Link
                   href="/projects"
                   className="p-3 rounded-md border border-gray-600 hover:bg-gray-200 ease-in duration-200 text-white hover:text-gray-900 "


### PR DESCRIPTION
Related Issue
Closes #1741

Description
I made a change by adding a my-1 class to provide margin and avoid overlap. The change is currently working fine.

Screenshots
Earlier:
![253855441-4d060dd1-afb8-4445-8495-1331dafb5120](https://github.com/priyankarpal/ProjectsHut/assets/109215419/dc6541ef-fa7e-41fc-abfc-04461013c296)


Updated:
![Screenshot 2023-07-17 at 7 10 10 PM](https://github.com/priyankarpal/ProjectsHut/assets/109215419/742890fb-5e4b-412c-8842-4e3f157dd0de)


Please find the revised statements below:

Changes Made
Added my-1 class to provide margin and avoid overlap.

Request for Review
Please review the changes and provide feedback.