### PR TITLE
fix: space consuming border for elements on intro page 🛠

### DIFF
--- a/components/Banner.tsx
+++ b/components/Banner.tsx
@@ -40,7 +40,7 @@ export default function Banner() {
         <div className="mx-auto mt-16 max-w-2xl sm:mt-20 lg:mt-24 lg:max-w-4xl">
           <dl className="grid max-w-xl grid-cols-1 gap-x-8 gap-y-10 lg:max-w-none lg:grid-cols-2 lg:gap-y-16">
             {features.map((feature) => (
-                            <div key={feature.name} className=" p-5 hover:border border-gray-600  rounded">
+                            <div key={feature.name} className=" p-5 hover:outline outline-1 outline-gray-600 rounded">
                 <div className="relative pl-16">
                   <dt className="text-base font-semibold leading-7 text-white">
                     <div className="absolute left-0 top-0 flex h-10 w-10 items-center justify-center rounded-lg bg-primary">


### PR DESCRIPTION
## Related Issue
Close #1798 

## Description
- This PR is about fixing the space consuming border behavior for elements on intro page.
- We resolved it using `outline` property, it's a new one and best alternative for `border` property on css.

## Screenshots

https://github.com/priyankarpal/ProjectsHut/assets/92252895/9d07ff09-4ee9-4bb6-a058-f328fcc84506
