### PR TITLE
fix: hidden copyright for mobile devices 🛠

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -70,7 +70,7 @@ function Footer() {
 
   return (
     < footer className="border-t border-gray-800 " >
-      <div className="mx-auto max-w-screen-xl px-4 pb-8 pt-16 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-screen-xl pt-16 sm:px-4 sm:pb-[5.65rem] lg:px-8 lg:pb-8">
         <div className="mt-16 grid grid-cols-1 gap-8 lg:grid-cols-2 lg:gap-32">
           <div className="mx-auto max-w-sm lg:max-w-none">
           <div className="inline-flex h-10 items-center text-white rounded-lg font-extrabold text-[2rem]"> Ph <span className="text-primary">.</span></div>
@@ -140,7 +140,7 @@ function Footer() {
         </div>
 
         <div className="mt-16 pt-8 dark:border-gray-800">
-          <p className="text-center text-xl text-gray-200">
+          <p className="text-center sm:text-xs lg:text-xl text-gray-200">
             ©projectshut {getCurrentYear()} All rights reserved
           </p>
         </div>

--- a/components/MobileNavbar.tsx
+++ b/components/MobileNavbar.tsx
@@ -7,7 +7,7 @@ import Link from 'next/link'
 
 export const MobileNavBar = () => {
     return (
-        <footer className="fixed bottom-1 w-1/11  left-0 right-0 bg-gray-800 text-white py-4 md:hidden rounded-xl mx-5">
+        <footer className="fixed bottom-4 w-1/11  left-0 right-0 bg-gray-800 text-white py-4 md:hidden rounded-xl mx-5">
             <div className="container mx-auto text-xl flex justify-between items-center px-4">
                 <Link href="/">
                     <AiFillHome className=" hover:text-primary"/>


### PR DESCRIPTION
## Related Issue
Close #1801 

## Description
- Fixed the hidden copyright bug which occured for mobile devices with tailwind css responsive utility classes.

## Screenshots

|BEFORE| AFTER |
| :---: | :---: |
| ![Screenshot_2023-07-22-15-27-44_1366x768](https://github.com/priyankarpal/ProjectsHut/assets/92252895/92689225-d6fe-4e58-972d-b40b065c9ee9) | ![image](https://github.com/priyankarpal/ProjectsHut/assets/92252895/4ef2ec6a-e590-4a87-b965-107c7c0613f5) |



