### PR TITLE
fix: browse projects button cut-off on homepage for mobile devices 🛠

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,7 @@ import images from "../DB/homepage-image.json";
 export default function HomePage() {
   return (
     <section>
-      <div className="relative overflow-hidden">
+      <div className="relative overflow-hidden sm:pb-4">
         <div className="pt-16 sm:pt-24 sm:pb-40 lg:pt-40 lg:pb-48">
           <div className="relative mx-auto max-w-7xl px-4 sm:static sm:px-6 lg:px-8">
             <section className="sm:max-w-[19.5rem] md:max-w-[24.5rem] tab:max-w-[28rem] lg:max-w-[30rem]">


### PR DESCRIPTION
## Related Issue
Close #1853 

## Screenshots
|BEFORE|AFTER|
|:----:|:----:|
| ![before](https://user-images.githubusercontent.com/92252895/256201435-8d8a4f79-325a-44de-a04f-f16565b88d27.png) | ![after](https://github.com/priyankarpal/ProjectsHut/assets/92252895/f9c3a2ad-a712-4ab9-ba75-e5c8fdeb5b20) |

