### PR TITLE
fix: improper way of hiding images on homepage 🛠

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,7 @@ import images from "../DB/homepage-image.json";
 export default function HomePage() {
   return (
     <section>
-      <div className="relative overflow-hidden sm:pb-4">
+      <div className="relative sm:pb-4">
         <div className="pt-16 sm:pt-24 sm:pb-40 lg:pt-40 lg:pb-48">
           <div className="relative mx-auto max-w-7xl px-4 sm:static sm:px-6 lg:px-8">
             <section className="sm:max-w-[19.5rem] md:max-w-[24.5rem] tab:max-w-[28rem] lg:max-w-[30rem]">
@@ -30,7 +30,7 @@ export default function HomePage() {
                 </Link>
               </div>
             </section>
-            <div className="py-8 xsm:px-0 md:px-4 absolute transform left-2 xs:left-1/4 xsm:-translate-x-1/5 xs:-translate-x-1/4 sm:left-1/2 sm:top-0 sm:translate-x-0 lg:top-1/2 lg:-translate-y-1/2 lg:translate-x-8 ">
+            <div className="hidden md:block py-8 xsm:px-0 md:px-4 absolute transform left-2 xs:left-1/4 xsm:-translate-x-1/5 xs:-translate-x-1/4 sm:left-1/2 sm:top-0 sm:translate-x-0 lg:top-1/2 lg:-translate-y-1/2 lg:translate-x-8 ">
               <div className="flex justify-center flex-grow items-center space-x-6 lg:space-x-8">
                 <div className="grid flex-shrink-0 grid-cols-1 gap-y-6 lg:gap-y-8">
                   {images.slice(0, 2).map((image, index) => (


### PR DESCRIPTION
## Related Issue
Close #1855 

## Description
- Fixed the improper way of hiding images by removing the `overflow-hidden` from Section and disabled the images block with `hidden` and make sure to display them on tablets and above devices with `block` utility class.

## Screenshots

![image](https://github.com/priyankarpal/ProjectsHut/assets/92252895/770c7c17-88fd-47d7-8fe8-37933d84ea12)

