### PR TITLE
style: made the footer in mobile view centered

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -107,7 +107,7 @@ function Footer() {
           </div>
 
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 mx-auto">
-            <ul className="font-medium text-gray-200 pt-5">
+            <ul className="font-medium text-gray-200 pt-5 text-center lg:text-left">
               {footerdocsLinks.map((section, index) => (
                 <div key={index}>
                   <h3 className="text-xl font-extrabold mb-4 text-gray-200">
@@ -118,7 +118,7 @@ function Footer() {
                       <li key={linkIndex} className="pt-2">
                         <Link
                           href={link.link}
-                          className="hover:text-primary"
+                          className="hover:text-primary "
                           rel="noopener noreferrer"
                           target="_blank"
                           aria-label="footer docs link"
@@ -132,7 +132,7 @@ function Footer() {
               ))}
             </ul>
 
-            <ul className="font-medium text-gray-200">
+            <ul className="font-medium text-gray-200 text-center lg:text-left">
               {footerServiceLinks.map((section, index) => (
                 <div key={index}>
                   <h3 className="text-xl font-extrabold mt-5 mb-4 text-gray-200">
@@ -143,9 +143,10 @@ function Footer() {
                       <li key={linkIndex} className="pt-2">
                         <Link
                           href={link.link}
-                          className="hover:text-primary"
+                          className="hover:text-primary  "
                           rel="noopener noreferrer"
                           target="_blank"
+
                           aria-label="footer service link"
                         >
                           {link.name}


### PR DESCRIPTION
Related Issue:-
Closes #1966

Description:-
Made changes in the Components/Footer.tsx file to improve the mobile view alignment. Added the text-center class to the <ul> element to center the content.

This change addresses issue #1966 by ensuring that the footer content is properly centered on mobile devices.

Screenshots:-
![Screenshot 2023-08-06 at 12 51 29 AM](https://github.com/priyankarpal/ProjectsHut/assets/109215419/3293f4da-a9e4-4748-bbef-b573f48b4684)
-
