### PR TITLE
style: add dark mode toggle functionality

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5,13 +5,16 @@
 }
 
 ::-webkit-scrollbar-thumb {
-  background: #ffffff;
+  @apply bg-gray-300 dark:bg-gray-600;
   border-radius: 10px;
 }
 
 html {
   font-family: "Inter", sans-serif;
-  background-color: #000000;
+}
+
+body {
+  @apply bg-white dark:bg-secondary text-gray-900 dark:text-gray-100 transition-colors duration-300;
 }
 
 /* animated image */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -66,12 +66,12 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en" className="light">
-      <body
-        className={`${inter.className} bg-white dark:bg-secondary transition-colors duration-300`}
-        suppressHydrationWarning={true}>
+    <html lang="en">
+      <body className={inter.className} suppressHydrationWarning={true}>
         <Navbar />
+
         {children}
+
         <MobileNavBar />
         <ScrollToTop />
         <Footer />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -66,12 +66,12 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
-      <body className={inter.className} suppressHydrationWarning={true}>
+    <html lang="en" className="light">
+      <body
+        className={`${inter.className} bg-white dark:bg-secondary transition-colors duration-300`}
+        suppressHydrationWarning={true}>
         <Navbar />
-
         {children}
-
         <MobileNavBar />
         <ScrollToTop />
         <Footer />

--- a/components/AddYourProjectsGuide.tsx
+++ b/components/AddYourProjectsGuide.tsx
@@ -7,7 +7,6 @@ import { MdOutlineContentCopy } from "react-icons/md";
 import { BsCheck2Circle } from "react-icons/bs";
 import { Motion } from "@/components/framer-motion";
 
-
 type StepProps = {
   steps: string;
   text: string;
@@ -45,14 +44,14 @@ const option1Steps = [
   {
     steps: "Step 2 : ",
     text: "Create a new Branch(click on main -> add name of your branch -> click on create branch:)",
-    image: 
-      "https://user-images.githubusercontent.com/80768852/258656607-64ad9db4-11a5-4dd8-ade8-21875c8831f7.jpg"
+    image:
+      "https://user-images.githubusercontent.com/80768852/258656607-64ad9db4-11a5-4dd8-ade8-21875c8831f7.jpg",
   },
   {
     steps: "Step 3 : ",
     text: "Click on Go to file",
     image:
-      "https://user-images.githubusercontent.com/80768852/258656827-b70c96bf-b8b9-4d0e-872e-c1f973841f25.jpg"
+      "https://user-images.githubusercontent.com/80768852/258656827-b70c96bf-b8b9-4d0e-872e-c1f973841f25.jpg",
   },
   {
     steps: "Step 4 : ",
@@ -69,11 +68,11 @@ const option1Steps = [
     steps: "Step 6 : ",
     text: "To create a pull request click on compare and pull request",
     image:
-      "https://user-images.githubusercontent.com/80768852/258657644-b1bc753b-3c0a-4853-8578-dde040c2665e.jpg"
+      "https://user-images.githubusercontent.com/80768852/258657644-b1bc753b-3c0a-4853-8578-dde040c2665e.jpg",
   },
   {
     steps: "Step 7 : ",
-    text: "Add an appropriate title and description to your PR explaining changes"
+    text: "Add an appropriate title and description to your PR explaining changes",
   },
   {
     steps: "Step 8 : ",
@@ -83,8 +82,8 @@ const option1Steps = [
       "https://user-images.githubusercontent.com/80768852/258657487-9fa9558c-e49b-4647-a9ee-50da86b9fccf.jpg",
   },
   {
-    text: "Congratulations🎉, you have made a PR to the ProjectsHut. Wait for your submission to be accepted and your PR to be merged by a maintainer."
-  }
+    text: "Congratulations🎉, you have made a PR to the ProjectsHut. Wait for your submission to be accepted and your PR to be merged by a maintainer.",
+  },
 ];
 
 const option2Steps = [
@@ -104,57 +103,57 @@ const option2Steps = [
     steps: "Step 2 : ",
     text: "Clone the repository",
     code: "git clone https://github.com/<your_username>/ProjectsHut.git",
-    image: 
-      "https://user-images.githubusercontent.com/80768852/258655867-6c74b8f4-ee2f-48e8-8fc1-38679143175f.png"
+    image:
+      "https://user-images.githubusercontent.com/80768852/258655867-6c74b8f4-ee2f-48e8-8fc1-38679143175f.png",
   },
   {
     steps: "Step 3 : ",
     text: "Navigate to the ProjectsHut directory",
     code: "cd ProjectsHut",
-    image: 
-      "https://user-images.githubusercontent.com/80768852/258653517-fefecfe1-1f74-444b-8837-120c9f57cebf.png"
+    image:
+      "https://user-images.githubusercontent.com/80768852/258653517-fefecfe1-1f74-444b-8837-120c9f57cebf.png",
   },
   {
     steps: "Step 4 : ",
     text: "Add a reference(remote) to the original repository",
     code: "git remote add upstream https://github.com/priyankarpal/ProjectsHut.git",
     image:
-      "https://user-images.githubusercontent.com/80768852/258653648-497133fd-c756-4065-9956-d2457b4ff53c.png"
+      "https://user-images.githubusercontent.com/80768852/258653648-497133fd-c756-4065-9956-d2457b4ff53c.png",
   },
   {
     steps: "Step 5 : ",
     text: "Check remotes for this repository",
     code: "git remote -v",
     image:
-      "https://user-images.githubusercontent.com/80768852/258653764-685d1dea-627c-4e4c-9444-c1ff05fb444e.png" 
+      "https://user-images.githubusercontent.com/80768852/258653764-685d1dea-627c-4e4c-9444-c1ff05fb444e.png",
   },
   {
     steps: "Step 6 : ",
     text: "Always take a pull from the upstream repository to your main branch to keep it updated as per the main project repository",
     code: "git pull upstream main",
     image:
-      "https://user-images.githubusercontent.com/80768852/258656123-fea37c96-d16b-43e3-807d-76a2c01a9d4a.png"
+      "https://user-images.githubusercontent.com/80768852/258656123-fea37c96-d16b-43e3-807d-76a2c01a9d4a.png",
   },
   {
     steps: "Step 7 : ",
     text: "install dependencies",
     code: "pnpm i",
     image:
-      "https://user-images.githubusercontent.com/80768852/258655966-ea8b5390-32d8-4f9e-8eb2-1eb840e9e7d1.png"
+      "https://user-images.githubusercontent.com/80768852/258655966-ea8b5390-32d8-4f9e-8eb2-1eb840e9e7d1.png",
   },
   {
     steps: "Step 8 : ",
     text: "Create a new Branch",
     code: "git checkout -b <your_branch_name>",
-    image: 
-      "https://user-images.githubusercontent.com/80768852/258654058-e0e8a964-56d1-4c33-91aa-0334771e8034.png"
+    image:
+      "https://user-images.githubusercontent.com/80768852/258654058-e0e8a964-56d1-4c33-91aa-0334771e8034.png",
   },
   {
     steps: "Step 9 : ",
     text: "Run the project",
     code: "pnpm dev",
     image:
-      "https://user-images.githubusercontent.com/80768852/258656216-24308a09-ae5a-4e7c-9c08-fbdd48e7f017.png"
+      "https://user-images.githubusercontent.com/80768852/258656216-24308a09-ae5a-4e7c-9c08-fbdd48e7f017.png",
   },
   {
     steps: "Step 10 : ",
@@ -165,19 +164,19 @@ const option2Steps = [
     text: "Check your changes",
     code: "git status",
     image:
-      "https://user-images.githubusercontent.com/80768852/258656155-874b051c-165a-4bde-8d2d-a32b05c0ac54.png"
+      "https://user-images.githubusercontent.com/80768852/258656155-874b051c-165a-4bde-8d2d-a32b05c0ac54.png",
   },
   {
     steps: "Step 12 : ",
     text: "Stage your changes",
     code: "git add . </files_that_you_made_changes>",
     image:
-      "https://user-images.githubusercontent.com/80768852/258654878-57d38c53-f5f4-476f-b5a9-c500dcc3403b.png"
+      "https://user-images.githubusercontent.com/80768852/258654878-57d38c53-f5f4-476f-b5a9-c500dcc3403b.png",
   },
   {
     steps: "Step 13 : ",
     text: "Commit your changes",
-    code: "git commit -m relevant message (add relevant message according to your issue and always add double quote to your message)",
+    code: 'git commit -m "relevant message" (add relevant message according to your issue and always add double quote to your message)',
     image:
       "https://user-images.githubusercontent.com/80768852/258654990-9a2685db-9419-4bb8-9899-821104a437a5.png",
   },
@@ -186,16 +185,17 @@ const option2Steps = [
     text: "Push your changes to the main branch",
     code: "git push -u origin <your_branch_name>",
     image:
-      "https://user-images.githubusercontent.com/80768852/258654547-7a0e300b-aada-4fa3-b1de-90d445c0311e.png"
-  },{
+      "https://user-images.githubusercontent.com/80768852/258654547-7a0e300b-aada-4fa3-b1de-90d445c0311e.png",
+  },
+  {
     steps: "Step 15 : ",
     text: "To create a pull request click on compare and pull request",
     image:
-      "https://user-images.githubusercontent.com/80768852/258657644-b1bc753b-3c0a-4853-8578-dde040c2665e.jpg"
+      "https://user-images.githubusercontent.com/80768852/258657644-b1bc753b-3c0a-4853-8578-dde040c2665e.jpg",
   },
   {
     steps: "Step 16 : ",
-    text: "Add an appropriate title and description to your PR explaining changes"
+    text: "Add an appropriate title and description to your PR explaining changes",
   },
   {
     steps: "Step 17 : ",
@@ -205,7 +205,7 @@ const option2Steps = [
       "https://user-images.githubusercontent.com/80768852/258657487-9fa9558c-e49b-4647-a9ee-50da86b9fccf.jpg",
   },
   {
-    text: "Congratulations🎉, you have made a PR to the ProjectsHut. Wait for your submission to be accepted and your PR to be merged by a maintainer."
+    text: "Congratulations🎉, you have made a PR to the ProjectsHut. Wait for your submission to be accepted and your PR to be merged by a maintainer.",
   },
 ];
 
@@ -222,23 +222,27 @@ function Step({ steps, text, code, image, index }: StepProps): JSX.Element {
   };
 
   return (
-    <Motion.div className="mt-5 flex flex-col gap-5 "
+    <Motion.div
+      className="mt-5 flex flex-col gap-5"
       initial={{ opacity: 0, y: 50 }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
-      transition={{ duration: 0.5, type: "spring", stiffness: 110 }}
-    >
-
-      <div className="flex items-center justify-between ">
+      transition={{ duration: 0.5, type: "spring", stiffness: 110 }}>
+      <div className="flex items-center justify-between">
         <Motion.div
           key={text}
           initial={{ opacity: 0, x: -50 }}
           whileInView={{ opacity: 1, x: 0 }}
           viewport={{ once: true }}
-          transition={{ duration: 0.5, type: "spring", stiffness: 110, delay: index * 0.15 }}
-          className="flex items-center justify-between gap-5 w-full ">
+          transition={{
+            duration: 0.5,
+            type: "spring",
+            stiffness: 110,
+            delay: index * 0.15,
+          }}
+          className="flex items-center justify-between gap-5 w-full">
           <div className="flex items-center gap-5">
-            <p className="text-base font-semibold leading-7 text-white">
+            <p className="text-base font-semibold leading-7 text-gray-900 dark:text-white">
               <b className="text-primary">{steps}</b>
               {text}
             </p>
@@ -248,14 +252,21 @@ function Step({ steps, text, code, image, index }: StepProps): JSX.Element {
               initial={{ opacity: 0, x: -50 }}
               whileInView={{ opacity: 1, x: 0 }}
               viewport={{ once: true }}
-              transition={{ duration: 0.5, type: "spring", stiffness: 110, delay: index * 0.20 }}
+              transition={{
+                duration: 0.5,
+                type: "spring",
+                stiffness: 110,
+                delay: index * 0.2,
+              }}
               className="flex items-end justify-end">
               <button
                 onClick={copyCode}
-                className="cursor-pointer text-indigo-600"
-              >
+                className="cursor-pointer text-gray-600 dark:text-indigo-600">
                 {copyCodeButton && (
-                  <MdOutlineContentCopy size="18" color="white" />
+                  <MdOutlineContentCopy
+                    size="18"
+                    className="text-gray-600 dark:text-white"
+                  />
                 )}
                 {!copyCodeButton && <BsCheck2Circle size="18" color="green" />}
               </button>
@@ -269,7 +280,12 @@ function Step({ steps, text, code, image, index }: StepProps): JSX.Element {
           initial={{ opacity: 0, x: -50 }}
           whileInView={{ opacity: 1, x: 0 }}
           viewport={{ once: true }}
-          transition={{ duration: 0.5, type: "spring", stiffness: 110, delay: index * 0.25 }}
+          transition={{
+            duration: 0.5,
+            type: "spring",
+            stiffness: 110,
+            delay: index * 0.25,
+          }}
           className="mt-2">
           <SyntaxHighlighter language="nginx" style={anOldHope}>
             {code}
@@ -281,8 +297,12 @@ function Step({ steps, text, code, image, index }: StepProps): JSX.Element {
           initial={{ opacity: 0, x: -50 }}
           whileInView={{ opacity: 1, x: 0 }}
           viewport={{ once: true }}
-          transition={{ duration: 0.5, type: "spring", stiffness: 110, delay: index * 0.30 }}
-        >
+          transition={{
+            duration: 0.5,
+            type: "spring",
+            stiffness: 110,
+            delay: index * 0.3,
+          }}>
           <Image
             src={image}
             alt={text}
@@ -319,47 +339,47 @@ export default function AddYourProjectsGuide(): JSX.Element {
     />
   ));
 
-  return (<>
-    <div className="flex justify-center mt-10">
-      <Motion.button
-        initial={{ opacity: 0, x: -50 }}
-        whileInView={{ opacity: 1, x: 0 }}
-        viewport={{ once: true }}
-        transition={{ duration: 0.5, type: "spring", stiffness: 110 }}
-        className={`mx-2 px-4 py-2 rounded-lg mb-4 ${selectedOption === 0
-          ? "bg-primary text-white"
-          : "border border-gray-700 text-gray-300"
+  return (
+    <>
+      <div className="flex justify-center mt-10">
+        <Motion.button
+          initial={{ opacity: 0, x: -50 }}
+          whileInView={{ opacity: 1, x: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.5, type: "spring", stiffness: 110 }}
+          className={`mx-2 px-4 py-2 rounded-lg mb-4 ${
+            selectedOption === 0
+              ? "bg-primary text-white"
+              : "border border-gray-700 text-gray-700 dark:text-gray-300"
           }`}
-        onClick={() => selectOption(0)}
-      >
-        Add Projects Directly From GitHub
-      </Motion.button>
-      <Motion.button
-        initial={{ opacity: 0, x: -50 }}
-        whileInView={{ opacity: 1, x: 0 }}
-        viewport={{ once: true }}
-        transition={{ duration: 0.5, type: "spring", stiffness: 110 }}
-
-        className={`mx-2 px-4 py-2 rounded-lg mb-4 ${selectedOption === 1
-          ? "bg-primary text-white"
-          : "border border-gray-700 text-gray-300"
+          onClick={() => selectOption(0)}>
+          Add Projects Directly From GitHub
+        </Motion.button>
+        <Motion.button
+          initial={{ opacity: 0, x: -50 }}
+          whileInView={{ opacity: 1, x: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.5, type: "spring", stiffness: 110 }}
+          className={`mx-2 px-4 py-2 rounded-lg mb-4 ${
+            selectedOption === 1
+              ? "bg-primary text-white"
+              : "border border-gray-700 text-gray-700 dark:text-gray-300"
           }`}
-        onClick={() => selectOption(1)}
-      >
-        Set Up Projects Locally
-      </Motion.button>
-    </div>
-    <article className="items-center max-w-5xl mx-auto">
-      <Motion.p className="mb-5 text-xl font-bold tracking-tight text-white"
-        initial={{ opacity: 0, x: -50 }}
-        whileInView={{ opacity: 1, x: 0 }}
-        viewport={{ once: true }}
-        transition={{ duration: 0.5, type: "spring", stiffness: 110 }}
-      >
-        Follow the following steps to add your projects to ProjectsHut :
-      </Motion.p>
-      <div className="option">{stepsRender}</div>
-    </article>
-  </>
+          onClick={() => selectOption(1)}>
+          Set Up Projects Locally
+        </Motion.button>
+      </div>
+      <article className="items-center max-w-5xl mx-auto">
+        <Motion.p
+          className="mb-5 text-xl font-bold tracking-tight text-gray-900 dark:text-white"
+          initial={{ opacity: 0, x: -50 }}
+          whileInView={{ opacity: 1, x: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.5, type: "spring", stiffness: 110 }}>
+          Follow these steps to add your projects to ProjectsHut:
+        </Motion.p>
+        <div className="option">{stepsRender}</div>
+      </article>
+    </>
   );
 }

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -11,12 +11,10 @@ function Footer() {
       name: "Twitter",
       link: "https://twitter.com/priyankarpal",
       icon: (
-        <SiX
-          aria-label="Follow us on Twitter"
-          title="Twitter(External Link)"
-        />
+        <SiX aria-label="Follow us on Twitter" title="Twitter(External Link)" />
       ),
-      hover: " text-xl  text-gray-200 cursor-pointer hover:text-purple-500 ",
+      hover:
+        "text-xl text-gray-700 dark:text-gray-200 cursor-pointer hover:text-purple-500",
     },
     {
       name: "GitHub",
@@ -27,7 +25,8 @@ function Footer() {
           title="GitHub(External Link)"
         />
       ),
-      hover: " text-xl  text-gray-200 cursor-pointer hover:text-purple-500 ",
+      hover:
+        "text-xl text-gray-700 dark:text-gray-200 cursor-pointer hover:text-purple-500",
     },
     {
       name: "Linkedin",
@@ -38,7 +37,8 @@ function Footer() {
           title="LinkedIn(External Link)"
         />
       ),
-      hover: " text-xl  text-gray-200 cursor-pointer hover:text-purple-700 ",
+      hover:
+        "text-xl text-gray-700 dark:text-gray-200 cursor-pointer hover:text-purple-700",
     },
   ];
 
@@ -79,16 +79,17 @@ function Footer() {
   ];
 
   return (
-    <footer className="w-full border-t border-gray-800 py-24">
+    <footer className="w-full border-t border-gray-200 dark:border-gray-800 py-24">
       <div className="mx-auto max-w-screen-xl pt-8 sm:pt-16 px-4 sm:px-6 lg:px-8 pb-8">
         <div className="grid grid-cols-1 gap-8 lg:grid-cols-2 lg:gap-4">
           <div className="text-center lg:text-left">
-            <div className="flex h-10 items-center justify-center lg:justify-start text-white rounded-lg font-extrabold text-2xl">
+            <div className="flex h-10 items-center justify-center lg:justify-start text-gray-900 dark:text-white rounded-lg font-extrabold text-2xl">
               Ph <span className="text-primary">.</span>
             </div>
-            <p className="mt-4 text-center text-gray-200 dark:text-gray-400 lg:text-left lg:text-lg">
+            <p className="mt-4 text-center text-gray-600 dark:text-gray-400 lg:text-left lg:text-lg">
               Projectshut is an open source web app that enables users to freely
-              publish their projects and create user profiles within the platform.
+              publish their projects and create user profiles within the
+              platform.
             </p>
 
             <div className="mt-6 flex justify-center lg:justify-start gap-4">
@@ -98,8 +99,7 @@ function Footer() {
                     href={footerLink.link}
                     target="_blank"
                     className={footerLink.hover}
-                    aria-label={`footer link of ${footerLink.link}`}
-                  >
+                    aria-label={`footer link of ${footerLink.link}`}>
                     {footerLink.icon}
                   </Link>
                 </li>
@@ -108,10 +108,10 @@ function Footer() {
           </div>
 
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 mx-auto">
-            <ul className="font-medium text-gray-200 pt-5 text-center lg:text-left">
+            <ul className="font-medium text-gray-700 dark:text-gray-200 pt-5 text-center lg:text-left">
               {footerdocsLinks.map((section, index) => (
                 <div key={index}>
-                  <h3 className="text-xl font-extrabold mb-4 text-gray-200">
+                  <h3 className="text-xl font-extrabold mb-4 text-gray-900 dark:text-gray-200">
                     {section.title}
                   </h3>
                   <ul>
@@ -122,8 +122,7 @@ function Footer() {
                           className="hover:text-primary "
                           rel="noopener noreferrer"
                           target="_blank"
-                          aria-label="footer docs link"
-                        >
+                          aria-label="footer docs link">
                           {link.name}
                         </Link>
                       </li>
@@ -133,10 +132,10 @@ function Footer() {
               ))}
             </ul>
 
-            <ul className="font-medium text-gray-200 text-center lg:text-left">
+            <ul className="font-medium text-gray-700 dark:text-gray-200 text-center lg:text-left">
               {footerServiceLinks.map((section, index) => (
                 <div key={index}>
-                  <h3 className="text-xl font-extrabold mt-5 mb-4 text-gray-200">
+                  <h3 className="text-xl font-extrabold mt-5 mb-4 text-gray-900 dark:text-gray-200">
                     {section.title}
                   </h3>
                   <ul>
@@ -147,9 +146,7 @@ function Footer() {
                           className="hover:text-primary  "
                           rel="noopener noreferrer"
                           target="_blank"
-
-                          aria-label="footer service link"
-                        >
+                          aria-label="footer service link">
                           {link.name}
                         </Link>
                       </li>
@@ -164,8 +161,7 @@ function Footer() {
                   href="https://github.com/priyankarpal/ProjectsHut"
                   target="_blank"
                   rel="noreferrer"
-                  aria-label="GitHub repository"
-                >
+                  aria-label="GitHub repository">
                   <Image
                     src="https://github.com/priyankarpal/ProjectsHut/assets/88102392/0fa9e8f0-349d-4cc8-8e01-1b6e2c27dbbb"
                     alt="Github-Share-Button"
@@ -177,13 +173,13 @@ function Footer() {
             </div>
           </div>
         </div>
-        <div className="mt-16 pt-8 dark:border-gray-800 text-center lg:text-center lg:text-left">
-          <p className="text-gray-200 mx-auto lg:mx-0">
+        <div className="mt-16 pt-8 border-t border-gray-200 dark:border-gray-800 text-center lg:text-left">
+          <p className="text-gray-700 dark:text-gray-200 mx-auto lg:mx-0">
             © ProjectsHut {getCurrentYear()} All rights reserved
           </p>
         </div>
       </div>
-    </footer >
+    </footer>
   );
 }
 

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -94,7 +94,7 @@ function Footer() {
 
             <div className="mt-6 flex justify-center lg:justify-start gap-4">
               {footerLinks.map((footerLink) => (
-                <li key={footerLink.link}>
+                <li key={footerLink.link} className="list-none">
                   <Link
                     href={footerLink.link}
                     target="_blank"

--- a/components/MobileNavbar.tsx
+++ b/components/MobileNavbar.tsx
@@ -1,9 +1,9 @@
-import React from 'react'
-import { AiFillHome } from 'react-icons/ai'
-import { MdExplore } from 'react-icons/md'
-import { BiSolidBookBookmark } from 'react-icons/bi'
-import { FaGithub } from 'react-icons/fa'
-import Link from 'next/link'
+import React from "react";
+import { AiFillHome } from "react-icons/ai";
+import { MdExplore } from "react-icons/md";
+import { BiSolidBookBookmark } from "react-icons/bi";
+import { FaGithub } from "react-icons/fa";
+import Link from "next/link";
 
 interface NavbarItem {
   icon: React.ReactElement;
@@ -36,7 +36,7 @@ const navbarItemsData: NavbarItem[] = [
 
 export const MobileNavBar = () => {
   return (
-    <footer className="fixed bottom-4 w-1/11  left-0 right-0 bg-transparent backdrop-blur-md border-gray-700 border text-white py-4 md:hidden rounded-xl mx-5">
+    <footer className="fixed bottom-4 w-1/11 left-0 right-0 bg-white dark:bg-secondary/80 backdrop-blur-md border-gray-200 dark:border-gray-700 border text-gray-800 dark:text-gray-200 py-4 md:hidden rounded-xl mx-5 transition-colors duration-300">
       <div className="mx-auto text-xl flex justify-evenly items-center px-4">
         {navbarItemsData.map((link, idx) => (
           <Link href={link.url} key={idx} aria-label="mobile navbar link">
@@ -48,5 +48,5 @@ export const MobileNavBar = () => {
         ))}
       </div>
     </footer>
-  )
-}
+  );
+};

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -39,28 +39,18 @@ const Navbar: NextPage = () => {
       <nav className="sticky top-0 z-50 w-full border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-secondary/80 backdrop-blur-md transition-colors duration-300">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-16">
-            <button
-              onClick={toggleTheme}
-              className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors duration-200"
-              aria-label="Toggle theme">
-              {darkMode ? (
-                <FiSun className="w-5 h-5 text-gray-800 dark:text-gray-200" />
-              ) : (
-                <FiMoon className="w-5 h-5 text-gray-800 dark:text-gray-200" />
-              )}
-            </button>
-
-            <div className="flex items-center space-x-4">
-              {/* Logo/Home Link */}
+            <Link
+              href="/"
+              className="text-xl font-bold text-gray-800 dark:text-white">
+              Ph<span className="text-primary">.</span>
+            </Link>
+            
+            <div className="hidden md:flex items-center space-x-4">
               <Link
                 href="/"
-                className="text-xl font-bold text-gray-800 dark:text-white">
-                ProjectsHut
+                className="text-gray-800 dark:text-gray-200 hover:text-primary dark:hover:text-primary px-3 py-2 rounded-md text-sm font-medium">
+                Home
               </Link>
-            </div>
-
-            {/* Navigation Links */}
-            <div className="hidden md:flex items-center space-x-4">
               <Link
                 href="/projects"
                 className="text-gray-800 dark:text-gray-200 hover:text-primary dark:hover:text-primary px-3 py-2 rounded-md text-sm font-medium">
@@ -78,6 +68,16 @@ const Navbar: NextPage = () => {
                 className="text-gray-800 dark:text-gray-200 hover:text-primary dark:hover:text-primary px-3 py-2 rounded-md text-sm font-medium">
                 GitHub
               </a>
+              <button
+                onClick={toggleTheme}
+                className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors duration-200"
+                aria-label="Toggle theme">
+                {darkMode ? (
+                  <FiSun className="w-5 h-5 text-gray-800 dark:text-gray-200" />
+                ) : (
+                  <FiMoon className="w-5 h-5 text-gray-800 dark:text-gray-200" />
+                )}
+              </button>
             </div>
           </div>
         </div>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,79 +1,85 @@
 "use client";
-import React, { Suspense } from "react";
+import React, { Suspense, useState, useEffect } from "react";
 import { NextPage } from "next";
 import Link from "next/link";
-import { NavLink } from "./NavLink";
-
-interface NavLink {
-  name: string;
-  path: string;
-  external?: boolean;
-}
+import { FiSun, FiMoon } from "react-icons/fi";
 
 const Navbar: NextPage = () => {
-  const navLinks: NavLink[] = [
-    {
-      name: "Home",
-      path: "/",
-    },
-    {
-      name: "Projects",
-      path: "/projects",
-    },
-    {
-      name: "Docs",
-      path: "/docs",
-    },
-    {
-      name: "GitHub",
-      path: "https://github.com/priyankarpal/ProjectsHut",
-      external: true,
-    },
-  ];
+  const [darkMode, setDarkMode] = useState(false);
+
+  useEffect(() => {
+    // Check for initial theme
+    if (
+      localStorage.theme === "dark" ||
+      (!("theme" in localStorage) &&
+        window.matchMedia("(prefers-color-scheme: dark)").matches)
+    ) {
+      setDarkMode(true);
+      document.documentElement.classList.add("dark");
+    } else {
+      setDarkMode(false);
+      document.documentElement.classList.remove("dark");
+    }
+  }, []);
+
+  const toggleTheme = () => {
+    if (darkMode) {
+      document.documentElement.classList.remove("dark");
+      localStorage.theme = "light";
+      setDarkMode(false);
+    } else {
+      document.documentElement.classList.add("dark");
+      localStorage.theme = "dark";
+      setDarkMode(true);
+    }
+  };
 
   return (
     <Suspense>
-      <nav className="top-0 z-10 sticky border-b border-gray-800 mx-auto bg-transparent backdrop-blur-sm">
-        <div className="flex justify-between md:justify-around p-5 w-full ">
-          {/* Logo for project Hut */}
-          <div className="item-navbar" id="logo-ph">
-            <Link
-              href="/"
-              className="inline-flex h-10 items-center text-white rounded-lg font-extrabold text-[2rem]"
-            >
-              Ph <span className="text-primary">.</span>
-            </Link>
-          </div>
+      <nav className="sticky top-0 z-50 w-full border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-secondary/80 backdrop-blur-md transition-colors duration-300">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex items-center justify-between h-16">
+            <div className="flex items-center space-x-4">
+              {/* Theme Toggle */}
+              <button
+                onClick={toggleTheme}
+                className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors duration-200"
+                aria-label="Toggle theme">
+                {darkMode ? (
+                  <FiSun className="w-5 h-5 text-gray-800 dark:text-gray-200" />
+                ) : (
+                  <FiMoon className="w-5 h-5 text-gray-800 dark:text-gray-200" />
+                )}
+              </button>
 
-          {/* Main element of navbar */}
-          <div
-            className="item-navbar hidden md:block"
-            id="elements-of-navbar"
-          >
-            <ul className="flex items-center gap-5 text-[1rem]">
-              {navLinks.map((navLink) => (
-                <li key={navLink.path}>
-                  {navLink.external ? (
-                    <NavLink
-                      href={navLink.path}
-                      aria-label="desktop navbar link"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className={(active)=> active ? "inline-block py-2 px-3 text-center text-primary hover:text-primary rounded-lg" : "inline-block py-2 px-3 text-center text-white hover:text-primary rounded-lg"}
-                    >
-                      {navLink.name}
-                    </NavLink>
-                  ) : (
-                    <NavLink
-                      href={navLink.path}
-                      className={(active)=> active ? "inline-block py-2 px-3 text-center text-primary hover:text-primary rounded-lg" : "inline-block py-2 px-3 text-center text-white hover:text-primary rounded-lg"}
-                    >
-                      {navLink.name}
-                    </NavLink>
-                  )}
-                </li>
-              ))}
-            </ul>
+              {/* Logo/Home Link */}
+              <Link
+                href="/"
+                className="text-xl font-bold text-gray-800 dark:text-white">
+                ProjectsHut
+              </Link>
+            </div>
+
+            {/* Navigation Links */}
+            <div className="hidden md:flex items-center space-x-4">
+              <Link
+                href="/projects"
+                className="text-gray-800 dark:text-gray-200 hover:text-primary dark:hover:text-primary px-3 py-2 rounded-md text-sm font-medium">
+                Projects
+              </Link>
+              <Link
+                href="/docs"
+                className="text-gray-800 dark:text-gray-200 hover:text-primary dark:hover:text-primary px-3 py-2 rounded-md text-sm font-medium">
+                Docs
+              </Link>
+              <a
+                href="https://github.com/priyankarpal/ProjectsHut"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-gray-800 dark:text-gray-200 hover:text-primary dark:hover:text-primary px-3 py-2 rounded-md text-sm font-medium">
+                GitHub
+              </a>
+            </div>
           </div>
         </div>
       </nav>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -39,19 +39,18 @@ const Navbar: NextPage = () => {
       <nav className="sticky top-0 z-50 w-full border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-secondary/80 backdrop-blur-md transition-colors duration-300">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-16">
-            <div className="flex items-center space-x-4">
-              {/* Theme Toggle */}
-              <button
-                onClick={toggleTheme}
-                className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors duration-200"
-                aria-label="Toggle theme">
-                {darkMode ? (
-                  <FiSun className="w-5 h-5 text-gray-800 dark:text-gray-200" />
-                ) : (
-                  <FiMoon className="w-5 h-5 text-gray-800 dark:text-gray-200" />
-                )}
-              </button>
+            <button
+              onClick={toggleTheme}
+              className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors duration-200"
+              aria-label="Toggle theme">
+              {darkMode ? (
+                <FiSun className="w-5 h-5 text-gray-800 dark:text-gray-200" />
+              ) : (
+                <FiMoon className="w-5 h-5 text-gray-800 dark:text-gray-200" />
+              )}
+            </button>
 
+            <div className="flex items-center space-x-4">
               {/* Logo/Home Link */}
               <Link
                 href="/"

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+// This component serves as the light/dark mode toggle switch.
+
+import { useState, useEffect } from 'react'
+import { FiSun, FiMoon } from 'react-icons/fi'
+
+export const ThemeToggle = () => {
+  const [darkMode, setDarkMode] = useState(true)
+
+  useEffect(() => {
+    const theme = localStorage.getItem('theme')
+    if (theme === 'light') setDarkMode(false)
+    else document.documentElement.classList.add('dark')
+  }, [])
+
+  const toggleTheme = () => {
+    if (darkMode) {
+      document.documentElement.classList.remove('dark')
+      localStorage.setItem('theme', 'light')
+    } else {
+      document.documentElement.classList.add('dark')
+      localStorage.setItem('theme', 'dark')
+    }
+    setDarkMode(!darkMode)
+  }
+
+  return (
+    <button
+      onClick={toggleTheme}
+      className="p-2 rounded-lg text-xl hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+      aria-label="Toggle theme"
+    >
+      {darkMode ? (
+        <FiSun className="text-white hover:text-primary" />
+      ) : (
+        <FiMoon className="text-gray-800 hover:text-primary" />
+      )}
+    </button>
+  )
+}

--- a/components/landing/Banner.tsx
+++ b/components/landing/Banner.tsx
@@ -36,8 +36,7 @@ export default function Banner() {
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.5, type: "spring", stiffness: 110 }}
-            className="mt-2 sm:mt-0 text-3xl font-bold tracking-tight text-white sm:text-4xl"
-          >
+            className="mt-2 sm:mt-0 text-3xl font-bold tracking-tight text-gray-900 dark:text-white sm:text-4xl">
             Why should you use this?
           </Motion.p>
           <Motion.h2
@@ -45,8 +44,7 @@ export default function Banner() {
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.5, type: "spring", stiffness: 110 }}
-            className="text-base font-semibold leading-7 text-primary"
-          >
+            className="text-base font-semibold leading-7 text-primary">
             Showcase your projects
           </Motion.h2>
         </div>
@@ -54,15 +52,10 @@ export default function Banner() {
           <dl className="grid max-w-xl grid-cols-1 gap-x-8 gap-y-10 lg:max-w-none lg:grid-cols-2 lg:gap-y-16">
             {features.map((feature, i) => (
               <Motion.div
-                // initial={{ opacity: 0, x: -640 }}
-                // whileInView={{ opacity: 1, x: 0 }}
-                // viewport={{ once: true }}
-                // transition={{ duration: 0.5, type: "spring", stiffness: 110, delay: i * 0.2 }}
                 key={feature.name}
-                className=" p-5 hover:outline outline-1 outline-gray-600 rounded"
-              >
+                className="p-5 hover:outline outline-1 outline-gray-600 rounded">
                 <div className="relative pl-16">
-                  <div className="text-base font-semibold leading-7 text-white">
+                  <div className="text-base font-semibold leading-7 text-gray-900 dark:text-white">
                     <Motion.div
                       initial={{ opacity: 0, x: -40 }}
                       whileInView={{ opacity: 1, x: 0 }}
@@ -73,8 +66,7 @@ export default function Banner() {
                         stiffness: 110,
                         delay: i * 0.2,
                       }}
-                      className="absolute left-0 top-0 flex h-10 w-10 items-center justify-center rounded-lg bg-primary"
-                    >
+                      className="absolute left-0 top-0 flex h-10 w-10 items-center justify-center rounded-lg bg-primary">
                       <feature.icon
                         className="h-6 w-6 text-white"
                         aria-hidden="true"
@@ -89,8 +81,7 @@ export default function Banner() {
                         type: "spring",
                         stiffness: 110,
                         delay: i * 0.2 + 0.1,
-                      }}
-                    >
+                      }}>
                       {feature.name}
                     </Motion.div>
                   </div>
@@ -104,8 +95,7 @@ export default function Banner() {
                       stiffness: 110,
                       delay: i * 0.2 + 0.2,
                     }}
-                    className="mt-2 text-base leading-7 text-gray-400"
-                  >
+                    className="mt-2 text-base leading-7 text-gray-600 dark:text-gray-400">
                     {feature.description}
                   </Motion.div>
                 </div>

--- a/components/landing/Home.tsx
+++ b/components/landing/Home.tsx
@@ -19,8 +19,7 @@ export default function Landing() {
                 stiffness: 110,
                 delay: 0,
               }}
-              className="text-4xl font-bold sm:text-[5vw] md:text-5xl lg:leading-[5.5rem] lg:text-[5rem] text-white"
-            >
+              className="text-4xl font-bold sm:text-[5vw] md:text-5xl lg:leading-[5.5rem] lg:text-[5rem] text-gray-900 dark:text-white">
               Learn. Build. Share.
             </Motion.div>
 
@@ -34,8 +33,7 @@ export default function Landing() {
                 stiffness: 110,
                 delay: 0.1,
               }}
-              className="mt-4 text-xl text-gray-400 tracking-wide "
-            >
+              className="mt-4 text-xl text-gray-600 dark:text-gray-400 tracking-wide">
               ProjectsHut is a platform where you can share your open source
               projects with the world.
             </Motion.p>
@@ -50,14 +48,12 @@ export default function Landing() {
                 stiffness: 110,
                 delay: 0.2,
               }}
-              className="mt-14 my-3"
-            >
+              className="mt-14 my-3">
               <Link
                 href="/projects"
-                className="p-3 rounded-md border border-gray-600 hover:bg-gray-200 ease-in duration-200 text-white hover:text-gray-900 "
+                className="p-3 rounded-md border border-gray-600 hover:bg-gray-200 dark:hover:bg-gray-800 ease-in duration-200 text-gray-900 dark:text-white"
                 type="button"
-                aria-label="link to projects section"
-              >
+                aria-label="link to projects section">
                 Browse Projects
               </Link>
             </Motion.div>
@@ -77,8 +73,7 @@ export default function Landing() {
                       delay: Math.random(),
                     }}
                     key={index}
-                    className="floating-image h-52 w-36 md:h-64 md:w-44 overflow-hidden rounded-lg"
-                  >
+                    className="floating-image h-52 w-36 md:h-64 md:w-44 overflow-hidden rounded-lg">
                     <Image
                       src={image.url}
                       alt={image.alt}
@@ -102,8 +97,7 @@ export default function Landing() {
                       delay: Math.random(),
                     }}
                     key={index}
-                    className="floating-image h-52 w-36 md:h-64 md:w-44 overflow-hidden rounded-lg "
-                  >
+                    className="floating-image h-52 w-36 md:h-64 md:w-44 overflow-hidden rounded-lg ">
                     <Image
                       src={image.url}
                       alt={image.alt}
@@ -127,8 +121,7 @@ export default function Landing() {
                       delay: Math.random(),
                     }}
                     key={i}
-                    className="floating-image h-52 w-36 md:h-64 md:w-44 overflow-hidden rounded-lg"
-                  >
+                    className="floating-image h-52 w-36 md:h-64 md:w-44 overflow-hidden rounded-lg">
                     <Image
                       src={image.url}
                       alt={image.alt}

--- a/components/projects/ProjectCard.tsx
+++ b/components/projects/ProjectCard.tsx
@@ -1,4 +1,4 @@
-'use client'
+"use client";
 import { NextPage } from "next";
 import Link from "next/link";
 import { BsArrowRightShort } from "react-icons/bs";
@@ -25,15 +25,25 @@ const ProjectCard: NextPage<ProjectCardType> = ({ project, index }) => {
       initial={{ opacity: 0, y: 50, scale: 0 }}
       whileInView={{ opacity: 1, y: 0, scale: 1 }}
       viewport={{ once: true }}
-      transition={{ duration: 0.1, type: "spring", stiffness: 110, delay: (index % 4) * 0.3 }}
+      transition={{
+        duration: 0.1,
+        type: "spring",
+        stiffness: 110,
+        delay: (index % 4) * 0.3,
+      }}
       className="border shadow-sm rounded-xl py-5 px-3 w-full h-full mb-3 max-w-md mx-auto sm:m-0  border-gray-700 hover:border-primary duration-200 shadow-slate-700/[.7]">
       <div className="flex justify-between items-center mb-3">
         <Motion.h1
           initial={{ opacity: 0, x: -50 }}
           whileInView={{ opacity: 1, x: 0 }}
           viewport={{ once: true }}
-          transition={{ duration: 0.3, type: "spring", stiffness: 110, delay: (index % 4) * 0.3 + 0.3 }}
-          className="normal-case text-lg/5 font-bold basis-full line-clamp-1 text-white ">
+          transition={{
+            duration: 0.3,
+            type: "spring",
+            stiffness: 110,
+            delay: (index % 4) * 0.3 + 0.3,
+          }}
+          className="normal-case text-lg/5 font-bold basis-full line-clamp-1 text-gray-900 dark:text-white">
           {title}
         </Motion.h1>
         <Image
@@ -49,11 +59,17 @@ const ProjectCard: NextPage<ProjectCardType> = ({ project, index }) => {
           initial={{ opacity: 0, x: -50 }}
           whileInView={{ opacity: 1, x: 0 }}
           viewport={{ once: true }}
-          transition={{ duration: 0.3, type: "spring", stiffness: 110, delay: (index % 4) * 0.3 + 0.4 }}
-          className="mb-2 line-clamp-2 text-white">{description}</Motion.p>
+          transition={{
+            duration: 0.3,
+            type: "spring",
+            stiffness: 110,
+            delay: (index % 4) * 0.3 + 0.4,
+          }}
+          className="mb-2 line-clamp-2 text-gray-800 dark:text-gray-200">
+          {description}
+        </Motion.p>
       </div>
-      <Motion.div
-        className="flex flex-row justify-between gap-5">
+      <Motion.div className="flex flex-row justify-between gap-5">
         {/*  GitHub Link Button */}
         <Link
           href={github_url}
@@ -61,20 +77,22 @@ const ProjectCard: NextPage<ProjectCardType> = ({ project, index }) => {
           rel="noreferrer"
           title="GitHub(External Link)"
           aria-label="Follow us on GitHub"
-          className="px-4 group active:scale-95 transition text-center text-white border w-1/2 border-gray-700 hover:border-gray-600  xl:text-[1rem] md:text-[0.8rem] rounded-md py-[0.35rem] "
-        >
+          className="px-4 group active:scale-95 transition text-center text-gray-900 dark:text-white border w-1/2 border-gray-700 hover:border-gray-600  xl:text-[1rem] md:text-[0.8rem] rounded-md py-[0.35rem] ">
           <Motion.div
             initial={{ opacity: 0, x: -50 }}
             whileInView={{ opacity: 1, x: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.3, type: "spring", stiffness: 110, delay: (index % 4) * 0.3 + 0.5 }}
-            className="flex gap-2 justify-center items-center"
-          >
+            transition={{
+              duration: 0.3,
+              type: "spring",
+              stiffness: 110,
+              delay: (index % 4) * 0.3 + 0.5,
+            }}
+            className="flex gap-2 justify-center items-center">
             GitHub
             <span
               className="group-hover:translate-x-1 duration-300 block"
-              aria-hidden="true"
-            >
+              aria-hidden="true">
               <BsArrowRightShort size={15} />
             </span>
           </Motion.div>
@@ -82,22 +100,24 @@ const ProjectCard: NextPage<ProjectCardType> = ({ project, index }) => {
         {/* for user profile card page button  */}
         <Link
           href={`/projects/${username.toLowerCase()}`}
-          className="w-1/2 px-4 group active:scale-95 transition text-center text-white border border-gray-700 hover:border-gray-600  xl:text-[1rem] md:text-[0.8rem] rounded-md py-[0.35rem] "
+          className="w-1/2 px-4 group active:scale-95 transition text-center text-gray-900 dark:text-white border border-gray-700 hover:border-gray-600  xl:text-[1rem] md:text-[0.8rem] rounded-md py-[0.35rem] "
           // state={{ filter }}
-          aria-label="visit user profile"
-        >
+          aria-label="visit user profile">
           <Motion.div
             initial={{ opacity: 0, x: -50 }}
             whileInView={{ opacity: 1, x: 0 }}
             viewport={{ once: true }}
-            transition={{ duration: 0.3, type: "spring", stiffness: 110, delay: (index % 4) * 0.3 + 0.5 }}
-            className="flex gap-2 justify-center items-center"
-          >
+            transition={{
+              duration: 0.3,
+              type: "spring",
+              stiffness: 110,
+              delay: (index % 4) * 0.3 + 0.5,
+            }}
+            className="flex gap-2 justify-center items-center">
             More
             <span
               className="group-hover:translate-x-1 duration-300 block"
-              aria-hidden="true"
-            >
+              aria-hidden="true">
               <BsArrowRightShort size={15} />
             </span>
           </Motion.div>

--- a/components/projects/ProjectList.tsx
+++ b/components/projects/ProjectList.tsx
@@ -49,11 +49,13 @@ function ProjectList() {
   // to get the user data from github
 
   const getData = async () => {
-    setInitialLoading(true); 
-    const userData = await  getUserData(params?.username as string) as userType;
+    setInitialLoading(true);
+    const userData = (await getUserData(
+      params?.username as string
+    )) as userType;
     setUser(userData);
     setInitialLoading(false);
-  }
+  };
 
   useEffect(() => {
     // make the scroll bar start from the top of the page
@@ -100,7 +102,7 @@ function ProjectList() {
       {initialLoading && <Loading.Profile />}
       {/* Left side profile section */}
       {!initialLoading && userObj && Object.keys(userObj).length > 0 && (
-        <div className="w-full md:w-[50%] md:h-5/6 lg:max-w-[35%] flex flex-col shadow-xl rounded-md mb-4 md:mb-0 md:sticky md:top-28 px-8 text-white border border-gray-800 mt-1">
+        <div className="w-full md:w-[50%] md:h-5/6 lg:max-w-[35%] flex flex-col shadow-xl rounded-md mb-4 md:mb-0 md:sticky md:top-28 px-8 text-gray-900 dark:text-white border border-gray-800 mt-1">
           {/* Back to projects link */}
           <div className="flex items-center justify-between my-4">
             <div>
@@ -108,8 +110,7 @@ function ProjectList() {
                 <Link
                   href="/projects"
                   className="flex items-stretch"
-                  aria-label="Back to projects link"
-                >
+                  aria-label="Back to projects link">
                   <MdArrowBackIosNew className="mt-0.5 text-[1.5rem]" />
                 </Link>
               </div>
@@ -117,8 +118,7 @@ function ProjectList() {
             {/* share button */}
             <div
               className="hover:text-purple-500 transition-all duration-500 ease-in-out flex cursor-pointer"
-              onClick={() => handleShareProfile()}
-            >
+              onClick={() => handleShareProfile()}>
               <FiShare2 className="text-[1.5rem]" />
             </div>
           </div>
@@ -137,24 +137,34 @@ function ProjectList() {
               @{params?.username}
             </h3>
           </div>
-          <div className="justify-center items-center text-center py-5 ">
-            <p className="text-sm break-words">{user?.bio}</p>
+          <div className="justify-center items-center text-center py-5">
+            <p className="text-sm break-words text-gray-700 dark:text-gray-300">
+              {user?.bio}
+            </p>
           </div>
           <div className="flex flex-row flex-wrap justify-center items-center xsm:mx-auto my-2 mb-5">
-            {user?.social_accounts && user?.social_accounts.map(({ provider, url, icon }: socialMediaType) => (
-              <div className="mx-4" key={provider}>
-                <Link
-                  href={url ?? ""}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="cursor-pointer inline-flex h-10 items-center rounded-lg  font-extrabold text-[1.5rem] hover:scale-110 transition-all duration-300 ease-in-out hover:text-purple-500"
-                  aria-label={`Follow us on ${provider}`}
-                  title={`${provider}(External Link)`}
-                >
-                  {icon ? icon : provider === "linkedin" ? <FaLinkedin /> : <FaTwitter />}
-                </Link>
-              </div>
-            ))}
+            {user?.social_accounts &&
+              user?.social_accounts.map(
+                ({ provider, url, icon }: socialMediaType) => (
+                  <div className="mx-4" key={provider}>
+                    <Link
+                      href={url ?? ""}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="cursor-pointer inline-flex h-10 items-center rounded-lg  font-extrabold text-[1.5rem] hover:scale-110 transition-all duration-300 ease-in-out hover:text-purple-500"
+                      aria-label={`Follow us on ${provider}`}
+                      title={`${provider}(External Link)`}>
+                      {icon ? (
+                        icon
+                      ) : provider === "linkedin" ? (
+                        <FaLinkedin />
+                      ) : (
+                        <FaTwitter />
+                      )}
+                    </Link>
+                  </div>
+                )
+              )}
           </div>
         </div>
       )}
@@ -172,26 +182,25 @@ function ProjectList() {
           userObj &&
           Object.keys(userObj).length > 0 &&
           userObj?.Projects.map((project, index) => (
-            <div key={index}
-              className="w-100 my-1 p-4 mb-4 text-white hover:border-primary border border-gray-800"
+            <div
+              key={index}
+              className="w-100 my-1 p-4 mb-4 text-gray-900 dark:text-white hover:border-primary border border-gray-800"
               style={{
                 borderRadius: "10px",
                 minHeight: "100px",
-              }}
-            >
+              }}>
               <div className=" border-b border-gray-600 p-4 relative">
                 <p className="capitalize text-lg/5 font-bold basis-full line-clamp-1">
                   {project.title}
                 </p>
-                <p className=" pr-[.5rem] text-[.9rem] my-4 xsm:mx-0 mx-4">
+                <p className="pr-[.5rem] text-[.9rem] my-4 xsm:mx-0 mx-4 text-gray-700 dark:text-gray-300">
                   {project.description}
                 </p>
                 <Link
                   href={project.github_url}
                   target="_blank"
                   rel="noreferrer"
-                  className="absolute top-[-.5rem] right-[-.2rem]"
-                >
+                  className="absolute top-[-.5rem] right-[-.2rem]">
                   <div className="inline-flex h-10 items-center rounded-lg font-extrabold text-[2rem] hover:scale-110 transition-all duration-300 ease-in-out  hover:text-primary">
                     <LuExternalLink size={25} />
                   </div>
@@ -203,8 +212,7 @@ function ProjectList() {
                   {project.tech.map((tag, i) => (
                     <p
                       className={`text-xs font-semibold inline-block py-1 px-2 .uppercase rounded-full uppercase mr-2 `}
-                      key={i}
-                    >
+                      key={i}>
                       {tag}
                     </p>
                   ))}
@@ -218,8 +226,7 @@ function ProjectList() {
           className="relative z-10"
           aria-labelledby="modal-title"
           role="dialog"
-          aria-modal="true"
-        >
+          aria-modal="true">
           <div className="fixed inset-0 bg-gray-500 bg-opacity-70 transition-opacity" />
 
           <div className="fixed inset-0 z-10 overflow-y-auto">
@@ -251,8 +258,7 @@ function ProjectList() {
 
                   <button
                     className="absolute top-5 right-7 duration-500"
-                    onClick={() => setIsOpenModal(false)}
-                  >
+                    onClick={() => setIsOpenModal(false)}>
                     <IoClose />
                   </button>
                 </div>

--- a/components/projects/Projects.tsx
+++ b/components/projects/Projects.tsx
@@ -212,8 +212,7 @@ const Projects = () => {
           stiffness: 110,
           delay: 0.2,
         }}
-        className="text-[2.5rem] font-bold text-center text-white"
-      >
+        className="text-[2.5rem] font-bold text-center text-gray-900 dark:text-white">
         Search for <span className="text-primary">cool</span> Projects
       </Motion.div>
       <Motion.div
@@ -226,13 +225,12 @@ const Projects = () => {
           stiffness: 110,
           delay: 0.3,
         }}
-        className="flex items-center justify-center my-7 mx-20"
-      >
+        className="flex items-center justify-center my-7 mx-20">
         <input
           type="text"
           id="combo-box-demo"
           placeholder="Search by project name"
-          className={`border-2 text-white outline-none duration-200  border-gray-700 hover:border-primary rounded-md p-2  bg-transparent `}
+          className={`border-2 text-gray-900 dark:text-white outline-none duration-200  border-gray-700 hover:border-primary rounded-md p-2  bg-transparent `}
           onChange={(e) => {
             handleOptionClick && handleOptionClick("project", e.target.value);
           }}
@@ -249,12 +247,10 @@ const Projects = () => {
           stiffness: 110,
           delay: 0.4,
         }}
-        className="flex items-stretch"
-      >
+        className="flex items-stretch">
         <button
-          className="border border-gray-600 hover:border-gray-500 rounded-md p-2 flex items-stretch text-white"
-          onClick={() => setOpenFilter(!openFilter)}
-        >
+          className="border border-gray-600 hover:border-gray-500 rounded-md p-2 flex items-stretch text-gray-900 dark:text-white"
+          onClick={() => setOpenFilter(!openFilter)}>
           Filter{" "}
           <div className="ml-2 ">
             {filterCount > 0 ? (
@@ -270,9 +266,8 @@ const Projects = () => {
         </button>
         {filterCount > 0 && (
           <button
-            className=" rounded-md border  border-gray-600 hover:border-gray-500 py-2 px-3 mx-2 text-white"
-            onClick={() => handleClear()}
-          >
+            className=" rounded-md border  border-gray-600 hover:border-gray-500 py-2 px-3 mx-2 text-gray-900 dark:text-white"
+            onClick={() => handleClear()}>
             <MdClear />
           </button>
         )}
@@ -282,8 +277,7 @@ const Projects = () => {
         <Dialog
           as="div"
           className="relative z-10"
-          onClose={() => setOpenFilter(false)}
-        >
+          onClose={() => setOpenFilter(false)}>
           <Transition.Child
             as={Fragment}
             enter="ease-out duration-300"
@@ -291,8 +285,7 @@ const Projects = () => {
             enterTo="opacity-100"
             leave="ease-in duration-200"
             leaveFrom="opacity-100"
-            leaveTo="opacity-0"
-          >
+            leaveTo="opacity-0">
             <div className="fixed inset-0 bg-black bg-opacity-25" />
           </Transition.Child>
 
@@ -305,19 +298,16 @@ const Projects = () => {
                 enterTo="opacity-100 scale-100"
                 leave="ease-in duration-200"
                 leaveFrom="opacity-100 scale-100"
-                leaveTo="opacity-0 scale-95"
-              >
+                leaveTo="opacity-0 scale-95">
                 <Dialog.Panel
                   className="w-full max-w-md transform overflow-hidden rounded-2xl bg-white p-6 text-left align-middle shadow-xl transition-all"
                   style={{
                     color: "black",
-                  }}
-                >
+                  }}>
                   <div className="flex justify-end w-full">
                     <button
                       className="bg-red-600 hover:bg-red-500 rounded-md border p-2 mx-2 gap-1 text-white"
-                      onClick={() => setOpenFilter(false)}
-                    >
+                      onClick={() => setOpenFilter(false)}>
                       <MdClear />
                     </button>
                   </div>
@@ -348,8 +338,7 @@ const Projects = () => {
                         } rounded-sm p-2`}
                         style={{
                           color: "black",
-                        }}
-                      >
+                        }}>
                         <span>{tech.toLowerCase()}</span>
                       </button>
                     ))}
@@ -377,10 +366,11 @@ const Projects = () => {
             }
             endMessage={
               <p style={{ textAlign: "center" }} className="py-5">
-                <b>Yay! You have seen it all</b>
+                <b className="text-gray-900 dark:text-white">
+                  Yay! You have seen it all
+                </b>
               </p>
-            }
-          >
+            }>
             {(searchitem.length == 0 ? visibleProjects : searchitem).map(
               (project: NewProjectsType, index: number) => (
                 <ProjectCard
@@ -397,7 +387,7 @@ const Projects = () => {
           </InfiniteScroll>
         ) : (
           <div className="flex justify-center items-center h-[50vh]">
-            <h1 className="text-2xl font-bold text-center text-white ">
+            <h1 className="text-2xl font-bold text-center text-gray-900 dark:text-white ">
               No Projects Found
             </h1>
           </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,6 +5,9 @@ module.exports = {
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
   ],
+
+  darkMode: 'class', // create dark mode class
+
   theme: {
     screens: {
       xsm: "240px",


### PR DESCRIPTION
## Related Issue: #2714 

## Description

I have added functionality for users to choose between dark and light mode on the website. This is done through editing the tailwind CSS config and creating a handler for the two modes. 
Since the styling of the text and layout was hardcoded to be black, I have also made sure the text is readable and clear on both themes.

## Screenshots

Here's how the different modes look on the Homepage and the Projects, though this applies to all of the pages.

<table>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/5cce4810-2d7b-4492-b6f6-e3ddbb9bbae3" width="350">
      <br>Homepage - Light Mode
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/b164f73b-e449-4576-a9e9-3cc2d286c6a6" width="350">
      <br>Homepage - Dark Mode
    </td>
  </tr>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/9af1c45a-df2a-43d4-a28d-033d343293f6" width="350">
      <br>Projects - Light Mode
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/6c0d922d-dd12-4ba6-a1da-57782567098e" width="350">
      <br>Projects - Dark Mode
    </td>
  </tr>
</table>
